### PR TITLE
(libretro) Restructure this

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2317,10 +2317,14 @@ void retro_run(void)
    if (updated)
       check_variables();
 
-   if (restart_eq) 
+   if (updated)
    {
-      audio_set_equalizer();
-      restart_eq = false;
+      check_variables();
+      if (restart_eq)
+      {
+         audio_set_equalizer();
+         restart_eq = false;
+      }
    }
 }
 


### PR DESCRIPTION
restart_eq is only changed after check_variables(), which in turn is only called (in this area) if 'updated' is true.